### PR TITLE
Fix a typo in deployment deletion error message

### DIFF
--- a/src/electron/menu.js
+++ b/src/electron/menu.js
@@ -69,7 +69,7 @@ export function deploymentOptions(info) {
             await now.deleteDeployment(info.uid)
           } catch (err) {
             console.error(err)
-            error('Wasn\'t not able to remove deployment ' + info.name)
+            error('Failed to remove deployment ' + info.name)
 
             return
           }


### PR DESCRIPTION
I suggest we change `wasn't` to `failed`, it sounds more sane to me that way.